### PR TITLE
feat(ingest): truncate all STG_LCR tables on historical back-fill

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# LCR ETL Pipeline
+
+This repository contains the scripts used to load Lead Custody Repository data into Snowflake.
+
+## Historical Load
+
+Run the ingestion pipeline once with `historical_load=True` to perform a clean full load of the staging tables:
+
+```
+python ingest.py  # ensure `historical_load=True` in `main()` or when calling `process_table`
+```
+
+This truncates all `STG_LCR_*` tables before inserting the data. After the initial back-fill completes, set `historical_load=False` for daily incremental runs.

--- a/tests/test_truncate.py
+++ b/tests/test_truncate.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import pytest
+from unittest import mock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+# Provide fake secrets for the ingest module
+os.environ.setdefault("KEY-VAULT-SECRET_DATAPRODUCT-SF-EDW-USER", "user")
+os.environ.setdefault("KEY-VAULT-SECRET_DATAPRODUCT-SF-EDW-PASS", "pass")
+
+import ingest
+
+
+def test_truncate_called_for_all_tables():
+    called = []
+
+    def _mock_truncate(name):
+        called.append(name)
+
+    with mock.patch.object(ingest, "truncate_table", side_effect=_mock_truncate), \
+         mock.patch.object(ingest, "load_raw_data", side_effect=RuntimeError("stop")):
+        for tbl in ingest.tables:
+            with pytest.raises(RuntimeError):
+                ingest.process_table(tbl, write_mode="append", historical_load=True)
+
+    assert set(called) == set(ingest.tables)


### PR DESCRIPTION
## Summary
- truncate staging tables during historical back-fills
- add test ensuring truncate runs for all tables
- document how to run a historical load

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684316c9d8888325880e297572eb847d