### PR TITLE
Fix ingest to remove sync dependency

### DIFF
--- a/sync.py
+++ b/sync.py
@@ -1,8 +1,7 @@
 from azure.storage.blob import BlobServiceClient
 from pyspark.sql import SparkSession
 from psycopg2 import pool, OperationalError, sql
-from typing import Dict, Optional
-import concurrent.futures
+from typing import Dict
 import logging
 import os
 import psycopg2
@@ -131,7 +130,6 @@ class PostgresDataHandler:
             }
 
             # Table name without quotes for JDBC
-            table_name = table.replace('"', '')
             schema, tbl = self._parse_table_name(table)
 
             # Use Spark's JDBC reader to load directly from PostgreSQL


### PR DESCRIPTION
## Summary
- refactor ingest to include its own Postgres helper
- tidy sync imports and unused variable

## Testing
- `ruff check ingest.py sync.py`
- `python -m py_compile ingest.py sync.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684448084388832587e1839201628958